### PR TITLE
[NEW] add tag-triggered docker release workflow pushing to Artifact Registry

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,91 @@
+name: Release Docker Image
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  IMAGE: asia-east1-docker.pkg.dev/ai-jiabao-com/mendesky/file-storage-context
+
+concurrency:
+  group: release-docker-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # tag push 事件不帶 branch 資訊 → 驗證 tag commit 在 main 歷史上才 release
+  guard:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    outputs:
+      on-main: ${{ steps.check.outputs.on-main }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check tag commit is ancestor of origin/main
+        id: check
+        run: |
+          git fetch origin main --quiet
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "on-main=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "on-main=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-push:
+    name: Build and push to Artifact Registry
+    needs: guard
+    if: needs.guard.outputs.on-main == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # swift release build + docker layers 很吃磁碟
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+
+      # 轉發給 Dockerfile 的 RUN --mount=type=ssh swift build
+      - name: Set up SSH agent for private packages
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.RELEASE_SSH_KEY }}
+
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: asia-east1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # latest 只在非預發布 tag(名稱不含 '-')時推,beta/dev 不蓋 latest
+      - name: Docker metadata (image tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          ssh: default
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/release-docker.yml`:main 上的 commit 被打 tag 並 push 後,自動 docker build 並 push 到 `asia-east1-docker.pkg.dev/ai-jiabao-com/mendesky/file-storage-context`(registry 既有 image 名)
- **Guard job**:驗證 tag commit 是 `origin/main` 的 ancestor,不在 main 上的 tag 直接 skip(不 build、不 red-X)
- **Image tags**:推 `<git tag 名>`;`latest` 只在非預發布 tag(名稱不含 `-`)時才推,避免 beta 蓋掉正式 latest
- **Private deps**:用 `RELEASE_SSH_KEY` 起 ssh-agent,`build-push-action` 以 `ssh: default` 轉發給 Dockerfile 的 `--mount=type=ssh swift build`
- 設計對齊 OpportunityContext 的 release-docker.yml(Mendesky/OpportunityContext#291)與 SOP 文件

## 前置條件(已完成,2026-08-04)

- [x] Secret `GCP_SA_KEY`(github-actions-push SA,`artifactregistry.writer`)
- [x] Secret `RELEASE_SSH_KEY` — 新設(deploy key on FileStorageContext,read-only)

## 已知限制

- `Package.resolved` 為 gitignored + 部分依賴 pin `branch: "main"` → 容器內每次全新 resolve,同一 git tag 重跑可能產出不同 image;要可重現 release 需改 tag pin

## Test plan

- YAML 語法已驗證(js-yaml)
- Merge 後打一個測試 tag,確認 guard → build(SSH 轉發、磁碟)→ push 全程通過(tag 觸發只認 default branch 上的 workflow,merge 前無法實測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 Docker 镜像自动发布流程。
  * 仅发布位于主分支历史中的有效标签。
  * 支持自动生成镜像标签、构建并推送镜像。
  * 预发布标签不会覆盖 `latest` 标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->