### PR TITLE
[FIX] sha256(extra:) 用 sortedKeys 讓 documentId 成為決定性內容雜湊

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,13 @@ let package = Package(
                 "GoogleCloudStorage"
             ]
         ),
+        // 不碰網路的純函式測試；GoogleCloudStorageTests 需要真實 GCS 憑證，跑不到雜湊這層。
+        .testTarget(
+            name: "FileStorageCoreTests",
+            dependencies: [
+                "FileStorageCore"
+            ]
+        ),
     ],
     swiftLanguageModes: [
         .v5

--- a/Sources/FileStorageCore/Data+Crypto.swift
+++ b/Sources/FileStorageCore/Data+Crypto.swift
@@ -18,8 +18,15 @@ extension Data {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
     
+    /// 以本身的 bytes 加上 `elements` 的 JSON 編碼計算 SHA-256。
+    ///
+    /// - Important: `.sortedKeys` 是**正確性要求**，不是格式偏好。少了它，JSON object 的 key 順序取自
+    ///   Swift `Dictionary` 的迭代順序，而其 hash seed 由 storage buffer 的記憶體位址推導 —— process 內只要
+    ///   有其他執行緒同時配置記憶體，順序就會變，同樣的輸入會算出不同的雜湊。實測相同輸入：單執行緒 200 次
+    ///   得 1 種結果、200 次併發得 9 種。這會讓所有以本函式產生的 `documentId` 當內容指紋的去重判斷失效。
     public func sha256(extra elements: Codable...) throws -> String {
         let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
         let elementDatas = try elements.map{
             try encoder.encode($0)
         }

--- a/Tests/FileStorageCoreTests/DataCryptoTests.swift
+++ b/Tests/FileStorageCoreTests/DataCryptoTests.swift
@@ -1,0 +1,54 @@
+//
+//  DataCryptoTests.swift
+//  FileStorageContext
+//
+
+import Foundation
+import Testing
+@testable import FileStorageCore
+
+/// `sha256(extra:)` 的輸出即 `documentId`（見 `StorageProtocol+ContextSupport.upload`），
+/// 而 `documentId` 同時是 GCS 的路徑末段與各 context 判斷「同一份檔案」的依據。
+/// 它必須是純粹的內容函式：同樣的輸入，在任何執行緒、任何負載下都得到同一個值。
+@Suite("Data.sha256(extra:) determinism")
+struct DataCryptoTests {
+
+    private let data = Data([UInt8](repeating: 0, count: 1024))
+    private let contextInfo = ContextStorageInfo(context: "OpportunityContext", category: "clientDocument")
+    private let metadata = StandardContextMetadata(
+        originalName: "日記帳.pdf",
+        context: "OpportunityContext",
+        aggregateRoot: "QuotingCaseGrouping",
+        aggregateRootId: "grouping-1"
+    )
+
+    /// **回歸測試**：本函式曾用未設 `.sortedKeys` 的 `JSONEncoder`，JSON object 的 key 順序取自 Swift
+    /// `Dictionary` 的迭代順序（hash seed 由 storage buffer 位址推導）→ 只要 process 內有其他執行緒同時
+    /// 在配置記憶體就會變。修復前這個測試會得到 6–9 種不同雜湊；單執行緒跑則看不出問題，故**必須併發**。
+    @Test("same input yields one hash under concurrency")
+    func concurrentHashIsStable() async throws {
+        let hashes = try await withThrowingTaskGroup(of: String.self) { group in
+            for _ in 0..<200 {
+                group.addTask { try self.data.sha256(extra: self.contextInfo, self.metadata) }
+            }
+            var collected = Set<String>()
+            for try await hash in group { collected.insert(hash) }
+            return collected
+        }
+
+        #expect(hashes.count == 1, "同樣的輸入必須只產生一個雜湊，實得 \(hashes.count) 種：\(hashes.sorted())")
+    }
+
+    /// **契約鎖**：`documentId` 一旦寫進各 context 的 event 就是永久識別碼，演算法變動會讓同一份檔案
+    /// 在新舊版本算出不同 id、彼此比不出重複。這支測試紅掉時要改的是程式碼，不是這裡的期望值。
+    @Test("hash of a known input is stable across releases")
+    func knownVector() throws {
+        #expect(try data.sha256(extra: contextInfo, metadata) == "9978b4d0ba5ec3257d0cf9ed0267a4cb6e542bafda1f15942ce5cfd41ca34e97")
+    }
+
+    /// 只雜湊 data 本身（不帶 extra）的路徑不受 JSON 編碼影響，用已知向量確認它一直是乾淨的。
+    @Test("hash without extra elements is the plain sha256 of the bytes")
+    func plainHash() {
+        #expect(data.sha256() == "5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef")
+    }
+}


### PR DESCRIPTION
## Summary

- `Data.sha256(extra:)` 的 `JSONEncoder` 未設 `.sortedKeys`，JSON object 的 key 順序取自 Swift `Dictionary` 的迭代順序（hash seed 由 storage buffer 的記憶體位址推導）→ **process 內只要有其他執行緒同時配置記憶體，同樣的輸入就會算出不同的雜湊**。實測相同輸入：單執行緒 200 次得 1 種、200 次併發得 10 種。
- 後果：`StorageProtocol+ContextSupport.upload` 產生的 `documentId` 不是穩定的內容指紋，**所有以它判斷「同一份檔案」的去重邏輯失效** —— 同一份檔案重傳會拿到不同 id 與不同的 GCS 物件。OpportunityContext 的客戶文件 `duplicateClientDocumentId` guard 就是被這個打穿而間歇失效。
- 加一個不碰網路的 `FileStorageCoreTests` target：現有的 `GoogleCloudStorageTests` 需要真實 GCS 憑證，跑不到雜湊這層。

## 相容性

**不需要 migration，既存檔案不受影響。** `documentId` 產生後即寫進各 context 的 event，`download(documentId:)` / `markDelete(documentId:)` 都用存下來的值重組路徑、不重算雜湊。已盤過 OpportunityContext / CustomerRelationshipContext / VersionManagementContext / Migration，沒有任何呼叫端會重算 id 去找既存檔案。

唯一的行為變化是**去重開始真的生效**：修復前上傳過的檔案，其 id 是舊的（未排序）演算法算出來的，再次上傳同一份檔案會得到新 id 而不被認出重複 —— 一次性的盲區，不是回歸（今天本來就幾乎攔不到）。

## Commits

- [FIX] sha256(extra:) 用 sortedKeys 讓 documentId 成為決定性內容雜湊

## Test plan

- [x] `swift test --filter "DataCryptoTests"` — 3 tests passed
- [x] 併發回歸測試確認會抓到本 bug：暫時移掉 `.sortedKeys` 後重跑，得到 10 種不同雜湊而失敗
- [ ] OpportunityContext 端整合驗證（以 `swift package edit` 指向本分支跑客戶文件測試）—— 尚未跑完

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化可编码数据的 SHA-256 生成，确保相同内容在不同执行顺序下产生稳定一致的哈希结果。
  * 固定 JSON 键排序，提升文档标识结果的跨版本一致性。

* **测试**
  * 新增哈希计算回归测试，覆盖并发场景、固定结果校验及纯内容 SHA-256 计算。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->