### PR TITLE
[UPDATE] upload 加 documentIdStrategy，讓重複的定義權回到各 context

### DIFF
--- a/Sources/FileStorageCore/ContextSupport/DocumentIdStrategy.swift
+++ b/Sources/FileStorageCore/ContextSupport/DocumentIdStrategy.swift
@@ -1,0 +1,39 @@
+//
+//  DocumentIdStrategy.swift
+//  FileStorageContext
+//
+
+import Foundation
+
+/// `documentId` 的產生策略。
+///
+/// **為什麼需要這個選擇**：`documentId` 決定 GCS 物件路徑，因此也決定了「什麼樣的兩次上傳會落在
+/// 同一個物件上」。`.contentHash` 把「同內容同檔名 ＝ 同一份文件」這個判斷內建在 storage 層；
+/// 但那不是所有 context 的業務規則 —— 例如同一份掃描檔要分別掛在集團內兩家公司底下、或掛在
+/// 兩個不同的文件分類底下時，storage 層的判斷反而會擋住合法操作。
+///
+/// 這個 enum 讓**重複的定義權回到各 context**：需要 storage 層去重的維持 `.contentHash`，
+/// 自己在 domain 層判重的改用 `.unique`。
+public enum DocumentIdStrategy: Sendable {
+    /// 由「檔案內容 ＋ contextInfo ＋ metadata」雜湊而得（library 的預設行為）。
+    ///
+    /// 特性：**冪等** —— 同樣的輸入永遠算出同一個 documentId、落在同一條 path，重試會覆蓋而非新增，
+    /// 因此上傳成功但後續步驟失敗時，重試不會累積孤兒物件。代價是無法讓「同內容的兩份文件」並存。
+    case contentHash
+
+    /// 每次上傳產生一個全新的 UUID，與檔案內容無關。
+    ///
+    /// 特性：同一份檔案可以並存多筆，重複與否**完全由呼叫端的 domain 規則決定**。
+    /// ⚠️ 代價是**失去冪等**：上傳成功但後續步驟失敗時，每次重試都會留下一個新的孤兒物件，
+    /// 呼叫端需自備補償（失敗時 `markDelete`）或離線清理機制。
+    case unique
+
+    func documentId(for data: Data, contextInfo: ContextStorageInfo, metadata: some ContextMetadata) throws -> String {
+        switch self {
+        case .contentHash:
+            return try data.sha256(extra: contextInfo, metadata)
+        case .unique:
+            return UUID().uuidString
+        }
+    }
+}

--- a/Sources/FileStorageCore/ContextSupport/StorageProtocol+ContextSupport.swift
+++ b/Sources/FileStorageCore/ContextSupport/StorageProtocol+ContextSupport.swift
@@ -7,9 +7,12 @@
 import Foundation
 
 extension StorageProtocol where MetadataType: ContextMetadata {
-    public func upload(data: Data, contextInfo: ContextStorageInfo, contentType: String, metadata: MetadataType, limit: FileSizeLimit) async throws -> ContextUploadedResult? {
-        let documentId = try data.sha256(extra: contextInfo, metadata)
-        
+    /// - Parameter documentIdStrategy: `documentId` 怎麼產生。預設 `.contentHash`＝既有行為，
+    ///   既有呼叫端無需改動。需要「同一份檔案可並存多筆、重複與否由自己的 domain 規則決定」的
+    ///   context 改傳 `.unique`（取捨見 `DocumentIdStrategy`）。
+    public func upload(data: Data, contextInfo: ContextStorageInfo, contentType: String, metadata: MetadataType, limit: FileSizeLimit, documentIdStrategy: DocumentIdStrategy = .contentHash) async throws -> ContextUploadedResult? {
+        let documentId = try documentIdStrategy.documentId(for: data, contextInfo: contextInfo, metadata: metadata)
+
         let folderPath = contextInfo.folderPath(metadata: metadata)
         let path = "\(folderPath)/\(documentId)"
         guard let result = try await upload(data: data, path: path, contentType: contentType, metadata: metadata, limit: limit) else {

--- a/Tests/FileStorageCoreTests/ContextUploadTests.swift
+++ b/Tests/FileStorageCoreTests/ContextUploadTests.swift
@@ -1,0 +1,90 @@
+//
+//  ContextUploadTests.swift
+//  FileStorageContext
+//
+
+import Foundation
+import Testing
+@testable import FileStorageCore
+
+/// 記錄 upload 收到的 path，其餘操作為 no-op。不碰網路。
+private actor PathRecordingStorage: StorageProtocol {
+    typealias MetadataType = StandardContextMetadata
+
+    private(set) var uploadedPaths: [String] = []
+
+    func upload(data: Data, path: String, contentType: String, metadata: [String: String]?, limit: FileSizeLimit) async throws -> UploadedResult? {
+        uploadedPaths.append(path)
+        return .init(path: path, mediaLink: "recorded://\(path)")
+    }
+
+    func setMetadata(_ metadata: [String: String], path: String) async throws {}
+    func getMetadata(path: String) async throws -> [String: String]? { nil }
+    func download(path: String) async throws -> DownloadResult? { nil }
+    func download(mediaLink: String) async throws -> DownloadResult? { nil }
+    func markDelete(path: String) async throws {}
+    func isMarkedDeleted(path: String) async throws -> Bool { false }
+}
+
+@Suite("Context upload documentId strategy")
+struct ContextUploadTests {
+
+    private let data = Data([UInt8](repeating: 0, count: 1024))
+    private let contextInfo = ContextStorageInfo(context: "OpportunityContext", category: "clientDocument")
+    private let metadata = StandardContextMetadata(
+        originalName: "日記帳.pdf",
+        context: "OpportunityContext",
+        aggregateRoot: "QuotingCaseGrouping",
+        aggregateRootId: "grouping-1"
+    )
+
+    /// **相容性鎖**：`documentIdStrategy` 是後加的預設參數，預設路徑**必須**與加它之前逐位元組相同。
+    /// 這個值同時是 `DataCryptoTests.knownVector` 鎖住的那個 —— 若哪天有人「順手」把預設換成
+    /// `.unique`、或改動雜湊輸入，所有既有 context 的重複判定會靜默失效，而這支測試會先紅。
+    @Test("default strategy keeps the historical documentId byte-for-byte")
+    func defaultStrategyIsUnchanged() async throws {
+        let storage = PathRecordingStorage()
+        let result = try #require(try await storage.upload(
+            data: data, contextInfo: contextInfo, contentType: "application/pdf",
+            metadata: metadata, limit: .mb(50)
+        ))
+
+        #expect(result.documentId == "9978b4d0ba5ec3257d0cf9ed0267a4cb6e542bafda1f15942ce5cfd41ca34e97")
+    }
+
+    /// 同樣的輸入、`.contentHash` → 同一個 documentId、同一條 path（冪等：重試會覆蓋而非新增）。
+    @Test("contentHash strategy is idempotent for identical input")
+    func contentHashIsIdempotent() async throws {
+        let storage = PathRecordingStorage()
+        let first = try #require(try await storage.upload(data: data, contextInfo: contextInfo, contentType: "application/pdf", metadata: metadata, limit: .mb(50), documentIdStrategy: .contentHash))
+        let second = try #require(try await storage.upload(data: data, contextInfo: contextInfo, contentType: "application/pdf", metadata: metadata, limit: .mb(50), documentIdStrategy: .contentHash))
+
+        #expect(first.documentId == second.documentId)
+        let paths = await storage.uploadedPaths
+        #expect(paths[0] == paths[1])
+    }
+
+    /// `.unique` → 同樣的輸入也得到不同的 documentId（重複與否交由呼叫端的 domain 規則判斷）。
+    @Test("unique strategy yields a distinct documentId per upload")
+    func uniqueIsDistinctPerUpload() async throws {
+        let storage = PathRecordingStorage()
+        let first = try #require(try await storage.upload(data: data, contextInfo: contextInfo, contentType: "application/pdf", metadata: metadata, limit: .mb(50), documentIdStrategy: .unique))
+        let second = try #require(try await storage.upload(data: data, contextInfo: contextInfo, contentType: "application/pdf", metadata: metadata, limit: .mb(50), documentIdStrategy: .unique))
+
+        #expect(first.documentId != second.documentId)
+        let paths = await storage.uploadedPaths
+        #expect(paths[0] != paths[1])
+    }
+
+    /// **路徑格式鎖**：folderPath 是 `{context}/{aggregateRoot}-{aggregateRootId}/{category}/{documentId}`。
+    /// download / markDelete 都靠同一個組法重建路徑，任一 component 改動都會讓既有檔案取不到，
+    /// 故格式本身就是契約。兩種策略只影響最後一段。
+    @Test("path shape is the contract, regardless of strategy", arguments: [DocumentIdStrategy.contentHash, .unique])
+    func pathShapeIsLocked(strategy: DocumentIdStrategy) async throws {
+        let storage = PathRecordingStorage()
+        let result = try #require(try await storage.upload(data: data, contextInfo: contextInfo, contentType: "application/pdf", metadata: metadata, limit: .mb(50), documentIdStrategy: strategy))
+
+        let paths = await storage.uploadedPaths
+        #expect(paths.first == "OpportunityContext/QuotingCaseGrouping-grouping-1/clientDocument/\(result.documentId)")
+    }
+}


### PR DESCRIPTION
## Summary

`documentId` 決定 GCS 物件路徑，因此也決定了「什麼樣的兩次上傳會落在同一個物件上」。目前的 `.contentHash` 把「**同內容同檔名 ＝ 同一份文件**」這個判斷內建在 storage 層 —— 但那不是所有 context 的業務規則。

實際撞到的情境（OpportunityContext 客戶文件）：同一份掃描檔要分別掛在**集團內兩家公司**底下，或掛在**兩個不同的文件分類**底下，都是合法操作，卻會被 storage 層算出同一個 documentId 而擋掉。

本 PR 把重複的定義權交回各 context：

```swift
public enum DocumentIdStrategy: Sendable {
    case contentHash   // 預設：既有行為
    case unique        // 每次一個新 UUID
}

func upload(..., documentIdStrategy: DocumentIdStrategy = .contentHash)
```

## 相容性

**既有呼叫端一行都不用改**，預設值即現行行為。已用測試鎖住「預設策略算出的 documentId 與加參數之前**逐位元組相同**」—— 這條很重要：若哪天有人順手把預設改成 `.unique`，各 context 那些 `contains { $0.documentId == documentId }` 形式的重複 guard 會**全部變成永不觸發的死碼**，而它們多半是直接呼叫 command 並手動塞同一個 id 來測，改完照樣全綠、沒有任何訊號。

⚠️ 一個實作細節：加預設參數會改變 mangled symbol，所以**不是 ABI 相容**。SwiftPM 從原始碼建置不受影響，但本機若有舊的增量建置產物可能需要 `swift package clean`（我在開發時就被 Demo target 的 stale object 擋了一次）。

## 兩種策略的取捨

| | `.contentHash` | `.unique` |
|---|---|---|
| 重試冪等 | ✅ 同輸入 → 同 path → 覆蓋，不累積孤兒 | ❌ 每次重試一個新物件 |
| 同內容多筆並存 | ❌ | ✅ |
| 重複由誰判定 | storage 層 | 呼叫端 domain |

選 `.unique` 的 context 需自備補償（失敗時 `markDelete`）或離線清理機制 —— doc comment 內有寫明。

## 誰在等這個

OpportunityContext 客戶文件的重複判定改版（PR #297）已在本地完成並驗證（56 tests 綠），但**卡在這支 tag** —— 那邊的 `Package.resolved` 仍 pin 1.2.6，發版後才能 bump 並 push。

## Test plan

- [x] `swift test --filter FileStorageCoreTests` — 7 tests passed
- [x] 相容性鎖：預設策略的 documentId 與 `DataCryptoTests` 既有的已知向量一致
- [x] `.contentHash` 冪等（兩次上傳同 path）、`.unique` 每次不同
- [x] folderPath 格式契約 `{context}/{aggregateRoot}-{aggregateRootId}/{category}/{documentId}`，兩種策略都鎖

🤖 Generated with [Claude Code](https://claude.com/claude-code)